### PR TITLE
use 0_deg.jpg as the app's menu icon

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -26,7 +26,8 @@
     {
       "type": "png",
       "name": "IMAGE_0_DEG",
-      "file": "0_deg.png"
+      "file": "0_deg.png",
+      "menuIcon" : true
     },
     {
       "type": "png",


### PR DESCRIPTION
And it works with **much** less clutter from cloudpebble. I didn't realize they did that.
Thanks again!
![iconpic](https://cloud.githubusercontent.com/assets/1807752/3489334/05696be6-0527-11e4-9822-840096be355d.jpg)
